### PR TITLE
Fix version file URL property

### DIFF
--- a/TransparentPods.version
+++ b/TransparentPods.version
@@ -1,6 +1,6 @@
 {
 	"NAME": "TransparentPods",
-	"URL": "https://forum.kerbalspaceprogram.com/index.php?/topic/187495-*",
+	"URL": "https://github.com/zer0Kerbal/TransparentPods/raw/master/TransparentPods.version",
 	"DOWNLOAD": "https://github.com/zer0Kerbal/TransparentPods/releases/latest",
 	"GITHUB": {
 		"USERNAME": "zer0Kerbal",


### PR DESCRIPTION
The URL property is supposed to point to an online copy of the version file that can be checked for updates, but currently it's the forum thread.
Now it's fixed.

Tagging @zer0Kerbal to ensure notifications are delivered by GitHub for this pull request.